### PR TITLE
select-component

### DIFF
--- a/src/components/SelectComponent/SelectComponent.tsx
+++ b/src/components/SelectComponent/SelectComponent.tsx
@@ -1,0 +1,16 @@
+import { SyntheticEvent } from "react";
+
+interface IProps {
+  options: { key: string, value: string }[]
+  onChange: (event: SyntheticEvent) => void
+}
+
+const SelectComponent = (props: IProps) => (
+  <select onChange={props.onChange}>
+    {props.options.map((item) => (
+      <option key={item.key} value={item.key}>{item.value}</option>
+    ))}
+  </select>
+);
+
+export default SelectComponent;


### PR DESCRIPTION
I've implemented `SelectComponent`. I used naming convention for handler prop. Also I read that everytime when we use `.map()` for generating html-markup, we have to use `key` attribute. It helps catch some changes in DOM. I didn't implement feature for multiselect. I think we won't use it.