### PR TITLE
card-component

### DIFF
--- a/src/components/CardComponent/CardComponent.tsx
+++ b/src/components/CardComponent/CardComponent.tsx
@@ -1,0 +1,20 @@
+interface IProps {
+  children: any,
+  classNames?: string[]
+}
+
+const CardComponent = (props: IProps) => {
+  const { classNames, children } = props;
+  const defaultClassNames = 'card';
+  const classNameString = classNames
+    ? classNames.join(' ') + ' ' + defaultClassNames
+    : defaultClassNames;
+
+  return (
+    <div className={classNameString}>
+      {children}
+    </div>
+  )
+}
+
+export default CardComponent;


### PR DESCRIPTION
Hi. I've implemented a wrapper (panel) for some content. I used React's default prop - `children`. I named this component as css class `.card` in mini.css library, that defined for our purposes (wrapping a logic block with content). CSS class `.card` don't have `padding` property, because inner container have to have a '.section' class that implement `padding` property. Also this component can take array of classes. This array need to set size of card component.